### PR TITLE
Format test_pr7rs and test_pr7rs_expected

### DIFF
--- a/test_pr7rs
+++ b/test_pr7rs
@@ -1,5 +1,5 @@
-; Tests for tr7rs
-(+ 1 1)
+{title:{Tests for tr7rs}}
+{id:0, test:{(+ 1 1)}}
 (* 2 3)
 (* (+ 1 1) 3)
 (= 1 2)

--- a/test_pr7rs
+++ b/test_pr7rs
@@ -1,4 +1,4 @@
-{title:{Tests for pr7rs}}
+{id:-1, test:{; Tests for pr7rs}}
 {id:0, test:{(+ 1 1)}}
 {id:1, test:{(* 2 3)}}
 {id:2, test:{(* (+ 1 1) 3)}}

--- a/test_pr7rs
+++ b/test_pr7rs
@@ -1,39 +1,39 @@
 {title:{Tests for pr7rs}}
 {id:0, test:{(+ 1 1)}}
-(* 2 3)
-(* (+ 1 1) 3)
-(= 1 2)
-(if (= 1 1) 1 2)
-(define list (lambda l l))
-(list 1 2 3)
-(car (list 1 2 3))
-(cdr (list 1 2 3))
-(cons 1 (list 2 3))
-(cons (list 1 2) (list 3 4))
-(define a (list 1 2))
-(car a)
-(cdr a)
-(null? (list))
-(null? (list 1))
-(null? 3)
-(define plus1 (lambda (x) (+ x 1)))
-(define add (lambda (x y) (+ x y)))
-(plus1 1)
-(add 2 3)
-(define fact (lambda (n) (if (< n 2) 1 (* n (fact (- n 1))))))
-(define S 5)
-(foo)
-(null? foo1)
-(+ 1 foo2)
-(fact 10)
-(((lambda (mk-length) (mk-length mk-length)) (lambda (mk-length) (lambda (l) (if (null? l) 0 (+ 1 ((mk-length mk-length) (cdr l))))))) (list 1 2 3))
-(define Y (lambda (le) ((lambda (f) (f f)) (lambda (f) (le (lambda (x) ((f f) x)))))))
-(define Y2 (lambda (le) ((lambda (f) (f f)) (lambda (f) (le (lambda (x1 x2) ((f f) x1 x2)))))))
-(define YS (lambda (le) ((lambda (f) (f f)) (lambda (f) (le (lambda x (apply (f f) x)))))))
-(define facty (Y (lambda (facty) (lambda (n) (if (< n 2) 1 (* n (facty (- n 1))))))))
-(facty 10)
-(define fooy2 (Y2 (lambda (fooy2) (lambda (l a) (cond ((null? l) a) (else (+ 1 (fooy2 (cdr l) a))))))))
-(fooy2 '(a b) 5)
+{id:1, test:{(* 2 3)}}
+{id:2, test:{(* (+ 1 1) 3)}}
+{id:3, test:{(= 1 2)}}
+{id:4, test:{(if (= 1 1) 1 2)}}
+{id:5, test:{(define list (lambda l l))}}
+{id:6, test:{(list 1 2 3)}}
+{id:7, test:{(car (list 1 2 3))}}
+{id:8, test:{(cdr (list 1 2 3))}}
+{id:9, test:{(cons 1 (list 2 3))}}
+{id:10, test:{(cons (list 1 2) (list 3 4))}}
+{id:11, test:{(define a (list 1 2))}}
+{id:12, test:{(car a)}}
+{id:13, test:{(cdr a)}}
+{id:14, test:{(null? (list))}}
+{id:15, test:{(null? (list 1))}}
+{id:16, test:{(null? 3)}}
+{id:17, test:{(define plus1 (lambda (x) (+ x 1)))}}
+{id:18, test:{(define add (lambda (x y) (+ x y)))}}
+{id:19, test:{(plus1 1)}}
+{id:20, test:{(add 2 3)}}
+{id:21, test:{(define fact (lambda (n) (if (< n 2) 1 (* n (fact (- n 1))))))}}
+{id:22, test:{(define S 5)}}
+{id:23, test:{(foo)}}
+{id:24, test:{(null? foo1)}}
+{id:25, test:{(+ 1 foo2)}}
+{id:26, test:{(fact 10)}}
+{id:27, test:{(((lambda (mk-length) (mk-length mk-length)) (lambda (mk-length) (lambda (l) (if (null? l) 0 (+ 1 ((mk-length mk-length) (cdr l))))))) (list 1 2 3))}}
+{id:28, test:{(define Y (lambda (le) ((lambda (f) (f f)) (lambda (f) (le (lambda (x) ((f f) x)))))))}}
+{id:29, test:{(define Y2 (lambda (le) ((lambda (f) (f f)) (lambda (f) (le (lambda (x1 x2) ((f f) x1 x2)))))))}}
+{id:30, test:{(define YS (lambda (le) ((lambda (f) (f f)) (lambda (f) (le (lambda x (apply (f f) x)))))))}}
+{id:31, test:{(define facty (Y (lambda (facty) (lambda (n) (if (< n 2) 1 (* n (facty (- n 1))))))))}}
+{id:32, test:{(facty 10)}}
+{id:33, test:{(define fooy2 (Y2 (lambda (fooy2) (lambda (l a) (cond ((null? l) a) (else (+ 1 (fooy2 (cdr l) a))))))))}}
+{id:34, test:{(fooy2 '(a b) 5)}}
 (define fooys (YS (lambda (fooys) (lambda k (cond ((null? (car k)) (car (cdr k))) (else (+ 1 (fooys (cdr (car k)) (car (cdr k))))))))))
 (define foos                      (lambda k (cond ((null? (car k)) (car (cdr k))) (else (+ 1 (foos  (cdr (car k)) (car (cdr k))))))))
 (fooys '(a b c) 9)

--- a/test_pr7rs
+++ b/test_pr7rs
@@ -1,4 +1,4 @@
-{title:{Tests for tr7rs}}
+{title:{Tests for pr7rs}}
 {id:0, test:{(+ 1 1)}}
 (* 2 3)
 (* (+ 1 1) 3)

--- a/test_pr7rs_expected
+++ b/test_pr7rs_expected
@@ -1,4 +1,4 @@
-> Nothing
+{id:-1, output:{Nothing}}
 > 2
 > 6
 > 6


### PR DESCRIPTION
Currently, the test_p7rs file is in pure pico scheme, hindering the learning of the language. There is currently no way to tell which test correlates to which expected result except by testing most of the lines. I want to fix this by formatting the two files so they can be interpreted by humans or computers.

- [ ] Format test_pr7rs
- [ ] Format test_pr7rs_expected
- [ ] Fix/create regression test